### PR TITLE
Fix role_assumption.py kwargs for role_set_env_vars

### DIFF
--- a/release.rst
+++ b/release.rst
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+* Fix missing kwargs in role assumption extension to enable `role_set_env_vars`
+
+Authors:
+
+* Li Chen

--- a/src/airflow_docker/ext/aws/role_assumption.py
+++ b/src/airflow_docker/ext/aws/role_assumption.py
@@ -108,9 +108,10 @@ class AWSRoleAssumptionExtension:
         role_session_duration: The number of seconds to assume the role for.
             Min: 900, Max: 43200 secs
             Defaults to Max of 43200 seconds (12 hours).
+        role_set_env_vars: Use environment variables to configure AWS credentials (Default: False)
     """
 
-    kwargs = {"role_arn", "role_session_duration"}
+    kwargs = {"role_arn", "role_session_duration", "role_set_env_vars"}
 
     @classmethod
     def post_prepare_environment(


### PR DESCRIPTION
Fix for the new `role_set_env_vars` feature